### PR TITLE
Fixed usage of Generator\DocBlock\Tag\ParamTag in ApiController

### DIFF
--- a/src/Mailjet/Controller/ApiController.php
+++ b/src/Mailjet/Controller/ApiController.php
@@ -153,11 +153,7 @@ LICENSE;
                     'Helper for ' . $metadata->Name . ' calls',
                     null,
                     array(
-                        new ReturnTag(
-                            array(
-                                'datatype' => ucfirst($metadata->Name),
-                            )
-                        ),
+                        new ReturnTag(ucfirst($metadata->Name)),
                     )
                 )
             );
@@ -432,11 +428,7 @@ LICENSE;
                     '',
                     array(
                         new ParamTag($name, $dataType),
-                        new ReturnTag(
-                            array(
-                                'datatype' => $class->getName(),
-                            )
-                        ),
+                        new ReturnTag($class->getName()),
                     )
                 )
             );
@@ -466,11 +458,7 @@ LICENSE;
                     'Gets the ' . $property->getDocBlock()->getShortDescription(),
                     '',
                     array(
-                        new ReturnTag(
-                            array(
-                                'datatype' => $dataType,
-                            )
-                        ),
+                        new ReturnTag($dataType),
                     )
                 )
             );
@@ -486,11 +474,7 @@ LICENSE;
                         'Add new item to ' . ucfirst($name),
                         '',
                         array(
-                            new ReturnTag(
-                                array(
-                                    'datatype' => 'bool',
-                                )
-                            ),
+                            new ReturnTag('bool'),
                         )
                     )
                 );
@@ -503,11 +487,7 @@ LICENSE;
                         'Remove $item from ' . ucfirst($name),
                         '',
                         array(
-                            new ReturnTag(
-                                array(
-                                    'datatype' => 'bool',
-                                )
-                            ),
+                            new ReturnTag('bool'),
                         )
                     )
                 );
@@ -559,12 +539,7 @@ LICENSE;
                                 . PHP_EOL ,
                                 array(
                                     new ParamTag('filters', 'array', 'key/val filters'),
-                                    new ReturnTag(
-                                        array(
-                                            'datatype' => 'ResultSet\ResultSet',
-                                            'description' => "List of $modelClassName",
-                                        )
-                                    ),
+                                    new ReturnTag('ResultSet\ResultSet', "List of $modelClassName"),
                                 )
                             )
                         ),
@@ -611,11 +586,7 @@ LICENSE;
                                         '',
                                         array(
                                             new ParamTag($filterName, $dataType),
-                                            new ReturnTag(
-                                                array(
-                                                    'datatype' => $isKey ? $modelClassName : 'ResultSet\ResultSet',
-                                                )
-                                            ),
+                                            new ReturnTag($isKey ? $modelClassName : 'ResultSet\ResultSet'),
                                         )
                                     )
                                 ),
@@ -640,11 +611,7 @@ LICENSE;
                                 '',
                                 array(
                                     new ParamTag('id', 'int', 'Id of resource to get'),
-                                    new ReturnTag(
-                                        array(
-                                            'datatype' => $modelClassName,
-                                        )
-                                    ),
+                                    new ReturnTag($modelClassName),
                                 )
                             )
                         ),
@@ -660,11 +627,7 @@ LICENSE;
                                 "Return current $modelClassName",
                                 '',
                                 array(
-                                    new ReturnTag(
-                                        array(
-                                            'datatype' => $modelClassName,
-                                        )
-                                    ),
+                                    new ReturnTag($modelClassName),
                                 )
                             )
                         ),
@@ -688,12 +651,7 @@ LICENSE;
                             '',
                             array(
                                 new ParamTag('id', 'integer', 'Id to delete'),
-                                new ReturnTag(
-                                    array(
-                                        'datatype' => 'bool',
-                                        'description' => 'True on success',
-                                    )
-                                ),
+                                new ReturnTag('bool', 'True on success'),
                             )
                         )
                     ),
@@ -719,12 +677,7 @@ LICENSE;
                             '',
                             array(
                                 new ParamTag($model, $modelClassName),
-                                new ReturnTag(
-                                    array(
-                                        'datatype' => "$modelClassName|false",
-                                        'description' => 'Object created or false',
-                                    )
-                                ),
+                                new ReturnTag("$modelClassName|false", 'Object created or false'),
                             )
                         )
                     ),
@@ -749,12 +702,7 @@ LICENSE;
                             '',
                             array(
                                 new ParamTag($model, $modelClassName),
-                                new ReturnTag(
-                                    array(
-                                        'datatype' => "$modelClassName|false",
-                                        'description' => 'Object created or false',
-                                    )
-                                ),
+                                new ReturnTag("$modelClassName|false", 'Object created or false'),
                             )
                         )
                     ),

--- a/src/Mailjet/Controller/ApiController.php
+++ b/src/Mailjet/Controller/ApiController.php
@@ -124,12 +124,7 @@ LICENSE;
                     'Mailjet Api',
                     'Wrapper used (as proxy) to consume apis',
                     array(
-                        new Generator\DocBlock\Tag(
-                            array(
-                                'name' => 'see',
-                                'description' => sprintf('http://mjdemo.poxx.net/~shubham'),
-                            )
-                        ),
+                        new Generator\DocBlock\Tag('see', sprintf('http://mjdemo.poxx.net/~shubham')),
                     )
                 )
             )
@@ -208,12 +203,7 @@ LICENSE;
                     $class->getName() . ' Api',
                     $metadata->Description,
                     array(
-                        new Generator\DocBlock\Tag(
-                            array(
-                                'name' => 'see',
-                                'description' => sprintf('http://mjdemo.poxx.net/~shubham/%s.html', $name),
-                            )
-                        ),
+                        new Generator\DocBlock\Tag('see', sprintf('http://mjdemo.poxx.net/~shubham/%s.html', $name)),
                     )
                 )
             )->addMethod(
@@ -441,12 +431,7 @@ LICENSE;
                     "Sets the " . $property->getDocBlock()->getShortDescription(),
                     '',
                     array(
-                        new ParamTag(
-                            array(
-                                'name' => $name,
-                                'datatype' => $dataType,
-                            )
-                        ),
+                        new ParamTag($name, $dataType),
                         new ReturnTag(
                             array(
                                 'datatype' => $class->getName(),
@@ -573,13 +558,7 @@ LICENSE;
                                 "Return list of $modelClassName filtered by \$filters if provided"
                                 . PHP_EOL ,
                                 array(
-                                    new ParamTag(
-                                        array(
-                                            'name' => 'filters',
-                                            'datatype' => 'array',
-                                            'description' => 'key/val filters',
-                                        )
-                                    ),
+                                    new ParamTag('filters', 'array', 'key/val filters'),
                                     new ReturnTag(
                                         array(
                                             'datatype' => 'ResultSet\ResultSet',
@@ -631,12 +610,7 @@ LICENSE;
                                         ($isKey ? "Return $modelClassName" : "Return list of $modelClassName with $filterName = \$$filterName"),
                                         '',
                                         array(
-                                            new ParamTag(
-                                                array(
-                                                    'name' => $filterName,
-                                                    'datatype' => $dataType,
-                                                )
-                                            ),
+                                            new ParamTag($filterName, $dataType),
                                             new ReturnTag(
                                                 array(
                                                     'datatype' => $isKey ? $modelClassName : 'ResultSet\ResultSet',
@@ -665,13 +639,7 @@ LICENSE;
                                 "Return $modelClassName with id = \$id",
                                 '',
                                 array(
-                                    new ParamTag(
-                                        array(
-                                            'name' => 'id',
-                                            'datatype' => 'int',
-                                            'description' => 'Id of resource to get',
-                                        )
-                                    ),
+                                    new ParamTag('id', 'int', 'Id of resource to get'),
                                     new ReturnTag(
                                         array(
                                             'datatype' => $modelClassName,
@@ -719,13 +687,7 @@ LICENSE;
                             "Delete the $model with id = \$id",
                             '',
                             array(
-                                new ParamTag(
-                                    array(
-                                        'name' => 'id',
-                                        'datatype' => 'integer',
-                                        'description' => 'Id to delete',
-                                    )
-                                ),
+                                new ParamTag('id', 'integer', 'Id to delete'),
                                 new ReturnTag(
                                     array(
                                         'datatype' => 'bool',
@@ -756,12 +718,7 @@ LICENSE;
                             "Create a new $model",
                             '',
                             array(
-                                new ParamTag(
-                                    array(
-                                        'name' => $model,
-                                        'datatype' => $modelClassName
-                                    )
-                                ),
+                                new ParamTag($model, $modelClassName),
                                 new ReturnTag(
                                     array(
                                         'datatype' => "$modelClassName|false",
@@ -791,12 +748,7 @@ LICENSE;
                             "Update existing $model",
                             '',
                             array(
-                                new ParamTag(
-                                    array(
-                                        'name' => $model,
-                                        'datatype' => $modelClassName
-                                    )
-                                ),
+                                new ParamTag($model, $modelClassName),
                                 new ReturnTag(
                                     array(
                                         'datatype' => "$modelClassName|false",


### PR DESCRIPTION
The current api generator is throwing a php warning from the usage of `DocBlock/Tag/ParamTag` class in `ApiController`.

    PHP Warning:  ltrim() expects parameter 1 to be string, array given in 
    ../vendor/zendframework/zendframework/library/Zend/Code/Generator/DocBlock/Tag/ParamTag.php on line 62

ZF2 class reference: https://github.com/zendframework/zf2/blob/master/library/Zend/Code/Generator/DocBlock/Tag/ParamTag.php#L27

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mailjet/mailjet-apiv3-php/3)
<!-- Reviewable:end -->
