### PR TITLE
Ignore composer.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ app/[Cc]onfig/database.php
 !empty
 composer.phar
 vendor/*
+composer.lock


### PR DESCRIPTION
This file is a Composer artifact that shouldn't be committed in PHP libraries.