### PR TITLE
Add compatibility with Guzzle 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.4.0",
-        "guzzlehttp/guzzle": "~5.3.0"
+        "guzzlehttp/guzzle": "~6.0|5.3"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
With this commit this library can now be installed on applications requiring Guzzle 5 or 6. Currently it's a conflict that prevents us to use the Mailjet API.