### PR TITLE
Remove installing dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
             "homepage": "https://dev.mailjet.com"
         }
     ],
-    "minimum-stability": "dev",
     "require": {
         "php": ">=5.4.0",
         "guzzlehttp/guzzle": "~5.3.0"


### PR DESCRIPTION
This option is not recommended as it installs unstable dependencies (it clones the master branch of dependencies instead of installing tags).