### PR TITLE
Fixes php errors when body attributes are not set. Fixes some other m…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "guzzlehttp/guzzle": "~6.0|5.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.3.*"
+        "phpunit/phpunit": "^4.8"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
         "php": ">=5.4.0",
         "guzzlehttp/guzzle": "~6.0|5.3"
     },
+    "require-dev": {
+        "phpunit/phpunit": "5.3.*"
+    },
     "autoload": {
         "psr-0": {
             "Mailjet": "src/"

--- a/src/Mailjet/Client.php
+++ b/src/Mailjet/Client.php
@@ -172,13 +172,14 @@ class Client
      * @param bool $bIsSecured True use https / false use http
      * @return bool true if we set value false otherwise
      */
-    public function setSecureProtocol( $bIsSecured ) {
-
+    public function setSecureProtocol($bIsSecured)
+    {
         if (is_bool($bIsSecured)) {
-
             $this->secure = $bIsSecured;
+
             return true;
         }
+
         return false;
     }
 }

--- a/src/Mailjet/Config.php
+++ b/src/Mailjet/Config.php
@@ -24,6 +24,6 @@ namespace Mailjet;
  */
 class Config
 {
-  const WRAPPER_VERSION = 'v1.1.1';
-  const USER_AGENT = 'mailjet-apiv3-php/';
+    const WRAPPER_VERSION = 'v1.1.1';
+    const USER_AGENT = 'mailjet-apiv3-php/';
 }

--- a/src/Mailjet/Request.php
+++ b/src/Mailjet/Request.php
@@ -42,10 +42,10 @@ class Request extends \GuzzleHttp\Client
     public function __construct($auth, $method, $url, $filters, $body, $type)
     {
         parent::__construct(['defaults' => [
-			'headers' => [
-				'user-agent' => \Mailjet\Config::USER_AGENT . phpversion() . '/' . \Mailjet\Client::WRAPPER_VERSION
-			]
-		]]);
+            'headers' => [
+                'user-agent' => \Mailjet\Config::USER_AGENT . phpversion() . '/' . \Mailjet\Client::WRAPPER_VERSION
+            ]
+        ]]);
         $this->type = $type;
         $this->auth = $auth;
         $this->method = $method;

--- a/src/Mailjet/Request.php
+++ b/src/Mailjet/Request.php
@@ -23,12 +23,12 @@ namespace Mailjet;
  */
 class Request extends \GuzzleHttp\Client
 {
-
     private $method;
     private $url;
     private $filters;
     private $body;
     private $auth;
+    private $type;
 
     /**
      * Build a new Http request
@@ -57,7 +57,8 @@ class Request extends \GuzzleHttp\Client
     /**
      * Trigger the actual call
      * TODO: DATA API
-     * @return the call response
+     * @param $call
+     * @return Response the call response
      */
     public function call($call)
     {
@@ -86,7 +87,7 @@ class Request extends \GuzzleHttp\Client
 
     /**
      * Filters getters
-     * @return Request filters
+     * @return array Request filters
      */
     public function getFilters()
     {
@@ -95,7 +96,7 @@ class Request extends \GuzzleHttp\Client
 
     /**
      * Http method getter
-     * @return Request method
+     * @return string Request method
      */
     public function getMethod()
     {
@@ -104,7 +105,7 @@ class Request extends \GuzzleHttp\Client
 
     /**
      * Call Url getter
-     * @return Request Url
+     * @return string Request Url
      */
     public function getUrl()
     {
@@ -113,7 +114,7 @@ class Request extends \GuzzleHttp\Client
 
     /**
      * Request body getter
-     * @return request body
+     * @return array request body
      */
     public function getBody()
     {
@@ -122,7 +123,7 @@ class Request extends \GuzzleHttp\Client
 
     /**
      * Auth getter. to discuss
-     * @return Request auth
+     * @return string Request auth
      */
     public function getAuth()
     {

--- a/src/Mailjet/Request.php
+++ b/src/Mailjet/Request.php
@@ -13,6 +13,9 @@
 
 namespace Mailjet;
 
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Exception\ClientException;
+
 /**
  * This is the Mailjet Request class
  * @category Mailjet_API
@@ -21,7 +24,7 @@ namespace Mailjet;
  * @license MIT https://licencepath.com
  * @link http://link.com
  */
-class Request extends \GuzzleHttp\Client
+class Request extends GuzzleClient
 {
     private $method;
     private $url;
@@ -43,7 +46,7 @@ class Request extends \GuzzleHttp\Client
     {
         parent::__construct(['defaults' => [
             'headers' => [
-                'user-agent' => \Mailjet\Config::USER_AGENT . phpversion() . '/' . \Mailjet\Client::WRAPPER_VERSION
+                'user-agent' => Config::USER_AGENT . phpversion() . '/' . Client::WRAPPER_VERSION
             ]
         ]]);
         $this->type = $type;
@@ -66,7 +69,7 @@ class Request extends \GuzzleHttp\Client
             'headers'  => ['content-type' => $this->type],
             'query' => $this->filters,
             'auth' => $this->auth,
-            ($this->type=="application/json"?'json':'body')=> $this->body,
+            ($this->type === 'application/json' ? 'json' : 'body') => $this->body,
         ];
 
         $response = null;
@@ -77,12 +80,12 @@ class Request extends \GuzzleHttp\Client
                     $this->url, $payload]
                 );
             }
-            catch (\GuzzleHttp\Exception\ClientException $e) {
+            catch (ClientException $e) {
                 $response = $e->getResponse();
             }
         }
 
-        return new \Mailjet\Response($this, $response);
+        return new Response($this, $response);
     }
 
     /**

--- a/src/Mailjet/Response.php
+++ b/src/Mailjet/Response.php
@@ -12,6 +12,7 @@
  */
 
 namespace Mailjet;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * This is the Mailjet Response
@@ -31,7 +32,7 @@ class Response
     /**
      * Construct a Mailjet response
      * @param Request        $request  Mailjet actual request
-     * @param GuzzleResponse $response Guzzle response
+     * @param ResponseInterface $response Guzzle response
      */
     public function __construct($request, $response)
     {

--- a/src/Mailjet/Response.php
+++ b/src/Mailjet/Response.php
@@ -56,8 +56,8 @@ class Response
 
     /**
      * Status Getter
-     * return the http status code
-     * @return int status
+     * return the entire response array
+     * @return array
      */
     public function getBody()
     {
@@ -73,19 +73,23 @@ class Response
     {
         if (isset($this->body['Data'])) {
             return $this->body['Data'];
-        } else {
-            return $this->body;
         }
+
+        return $this->body;
     }
 
     /**
      * Count getter
      * return the resulting array size
-     * @return int count
+     * @return null|int
      */
     public function getCount()
     {
-        return $this->body['Count'];
+        if (isset($this->body['Count'])) {
+            return $this->body['Count'];
+        }
+
+        return null;
     }
 
     /**
@@ -95,7 +99,11 @@ class Response
      */
     public function getTotal()
     {
-        return $this->body['Total'];
+        if (isset($this->body['Total'])) {
+            return $this->body['Total'];
+        }
+
+        return null;
     }
 
     /**

--- a/src/Mailjet/Response.php
+++ b/src/Mailjet/Response.php
@@ -24,7 +24,6 @@ use Psr\Http\Message\ResponseInterface;
  */
 class Response
 {
-
     private $status;
     private $success;
     private $body;

--- a/test/Mailjet/test.php
+++ b/test/Mailjet/test.php
@@ -1,10 +1,8 @@
 <?php
 
-namespace mailjet;
-use \Mailjet\Resources;
+namespace Mailjet;
 
-require 'vendor/autoload.php';
-
+require __DIR__.'/../../vendor/autoload.php';
 
 class MailjetTest extends \PHPUnit_Framework_TestCase
 {
@@ -26,7 +24,7 @@ class MailjetTest extends \PHPUnit_Framework_TestCase
 
     public function testGet()
     {
-        $client = new \Mailjet\Client('', '', false);
+        $client = new Client('', '', false);
 
         $this->assertUrl('/REST/contact', $client->get(Resources::$Contact));
 
@@ -44,7 +42,7 @@ class MailjetTest extends \PHPUnit_Framework_TestCase
         $this->assertUrl('/REST/contact', $response);
 
         $this->assertUrl('/REST/contact/2', $client->get(Resources::$Contact, ['id' => 2]));
-        
+
         $this->assertUrl(
             '/REST/contact/test@mailjet.com',
             $client->get(Resources::$Contact, ['id' => 'test@mailjet.com'])
@@ -53,7 +51,7 @@ class MailjetTest extends \PHPUnit_Framework_TestCase
 
     public function testPost()
     {
-        $client = new \Mailjet\Client('', '', false);
+        $client = new Client('', '', false);
 
         $email = [
           'FromName'     => 'Mailjet PHP test',
@@ -70,4 +68,3 @@ class MailjetTest extends \PHPUnit_Framework_TestCase
         $this->assertPayload($email, $ret);
     }
 }
-?>


### PR DESCRIPTION
Hi

I was testing your PHP library today and I ran into some issues when sending a basic email as described here http://dev.mailjet.com/guides/#sending-a-basic-email I was using the following API call:

```php
$body => array(
    FromEmail => "sender@email.com",
    FromName => "Sender Name",
    To => "recipient@email.com",
    Cc => "",
    Bcc => "",
    Subject => "Delectus tempora eveniet",
    Text-part => null,
    Html-part => "some html",
);

$client->post(Resources::$Email, ['body' => $body]);
```

The email was sent just fine, but there are some issues with the library when using some of the getters. Some fields on the `body` array (response) are not set and as such should be checked before accessing them directly in the response. Also, the phpdoc for the `getBody` method was wrong.

Let me know if the changes make sense to you.