### PR TITLE
adding support for DATA errorfile

### DIFF
--- a/src/Mailjet/Client.php
+++ b/src/Mailjet/Client.php
@@ -150,6 +150,7 @@ class Client
             $path = '';
         } elseif ($action == 'csverror/text:csv'
             || $action == 'csvdata/text:plain'
+            || $action == 'JSONError/application:json/LAST'
         ) {
             $path = 'DATA';
         } else {

--- a/src/Mailjet/Resources.php
+++ b/src/Mailjet/Resources.php
@@ -34,6 +34,8 @@ class Resources
     public static $Apitoken = ['apitoken', ''];
     public static $Axtesting = ['axtesting', ''];
     public static $Batchjob = ['batchjob', ''];
+    public static $BatchjobCsverror = ['batchjob', 'csverror/text:csv'];
+    public static $BatchjobJsonerror = ['batchjob', 'JSONError/application:json/LAST'];
     public static $Bouncestatistics = ['bouncestatistics', ''];
     public static $Campaign = ['campaign', ''];
     public static $Campaignaggregate = ['campaignaggregate', ''];


### PR DESCRIPTION
When an error occur on /contactslist/managemanycontact POST , an error file is created

see https://dev.mailjet.com/guides/?shell#monitoring-the-upload-of-multiple-contacts

This PR allow to GET the data error file with : 

$mj->get(['batchjob', 'JSONError/application:json/LAST'] , ['id' => $JobID]);

