### PR TITLE
use tilde operator in composer for guzzle 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "guzzlehttp/guzzle": "~6.0|5.3"
+        "guzzlehttp/guzzle": "~6.0|~5.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8"


### PR DESCRIPTION
This was required for us to resolve conflict with https://github.com/aws/aws-sdk-php which specifies `^5.3.1`