### PR TITLE
I installed mailjet-apiv3-php (the latest master).

### DIFF
--- a/src/Mailjet/Client.php
+++ b/src/Mailjet/Client.php
@@ -61,8 +61,6 @@ class Client
             'actionid' => '',
             'filters' => [],
             'body' => null
-            //'body' => '{}' -> when we make get request this argument has to be null, else it returns status code 411 - Length required
-
             ],
             array_change_key_case($args)
         );

--- a/src/Mailjet/Client.php
+++ b/src/Mailjet/Client.php
@@ -60,7 +60,9 @@ class Client
             'id' => '',
             'actionid' => '',
             'filters' => [],
-            'body' => '{}'
+            'body' => null
+            //'body' => '{}' -> when we make get request this argument has to be null, else it returns status code 411 - Length required
+
             ],
             array_change_key_case($args)
         );

--- a/src/Mailjet/Client.php
+++ b/src/Mailjet/Client.php
@@ -57,10 +57,10 @@ class Client
     {
         $args = array_merge(
             [
-            'id' => '',
-            'actionid' => '',
-            'filters' => [],
-            'body' => null
+                'id' => '',
+                'actionid' => '',
+                'filters' => [],
+                'body' => $method == 'GET' ? null : '{}',
             ],
             array_change_key_case($args)
         );


### PR DESCRIPTION
Then tried to make my first call (from the README).
The response status is 411 - Length required.

If I make a post request then everything is working fine.
The problem is with the get method.
We solved the problem as following:
In Client class, method _call, we set 'body' => null instead of '{}'.