### PR TITLE
Modify the space problem and include autoload.php approach

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit colors="true">
+<phpunit 
+    colors="true"
+    bootstrap="./vendor/autoload.php">
     <testsuites>
         <testsuite name="Mailjet APIv3 PHP wrapper test suite">
             <file>./test/Mailjet/test.php</file>

--- a/test/Mailjet/test.php
+++ b/test/Mailjet/test.php
@@ -85,7 +85,7 @@ class MailjetTest extends \PHPUnit_Framework_TestCase
         $this->assertPayload($email, $ret);
     }
 	
-	public function testClientHasOptions()
+    public function testClientHasOptions()
     {
          $client = new Client('', '', ['call' => false]);
          $client->setTimeout(3);

--- a/test/Mailjet/test.php
+++ b/test/Mailjet/test.php
@@ -2,8 +2,6 @@
 
 namespace Mailjet;
 
-require __DIR__.'/../../vendor/autoload.php';
-
 class MailjetTest extends \PHPUnit_Framework_TestCase
 {
     private function assertUrl($url, $response, $version = 'v3')


### PR DESCRIPTION
# Change log

- Solve the space problem in ```test.php```.
- Let the ```autoload.php``` add in ```phpunit.xml.dist``` because the ```autoload.php``` should not be included in ```test.php``` manually.