### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ app/[Cc]onfig/database.php
 .DS_Store
 !empty
 composer.phar
-vendor/*
+
 composer.lock


### PR DESCRIPTION
remove the vendor/* so we can have the autoload.php script and not be forced into using composer. TY.