### PR TITLE
Fix auth (basic / token) settings

### DIFF
--- a/src/Mailjet/Client.php
+++ b/src/Mailjet/Client.php
@@ -152,7 +152,7 @@ class Client
      */
     private function _isBasicAuthenticationRequired($key, $secret)
     {
-        return is_string($key) && is_string($secret) && empty($secret);
+        return is_string($key) && is_string($secret) && !empty($secret);
     }
 
     /**

--- a/src/Mailjet/Client.php
+++ b/src/Mailjet/Client.php
@@ -54,12 +54,12 @@ class Client
                                 array $settings = [])
     {
         $isBasicAuthentication = $this->_isBasicAuthenticationRequired($key, $secret);
-        
+
         if ($isBasicAuthentication) {
             $this->_setBasicAuthentication($key, $secret, $call, $settings);
         } else {
-            $this->_setTokenAuthetication($key, $secret, $call);
-        }        
+            $this->_setTokenAuthetication($key, $call);
+        }
     }
 
     /**
@@ -87,14 +87,14 @@ class Client
         $contentType = ($action == 'csvdata/text:plain' || $action == 'csverror/text:csv')
                 ?
             'text/plain' : 'application/json';
-        
+
         $auth = (isset($this->apisecret) && is_string($this->apisecret) !== '') ? [
             $this->apikey,
             $this->apisecret
         ] : [
             $this->apitoken
         ];
-        
+
         $request     = new Request(
             $auth, $method, $url, $args['filters'],
             $args['body'], $contentType, $this->requestOptions
@@ -114,7 +114,7 @@ class Client
     }
 
     /**
-     * 
+     *
      * @param string $key
      * @param string $secret
      * @param boolean $call
@@ -129,7 +129,7 @@ class Client
     }
 
     /**
-     * 
+     *
      * @param string $token
      * @param boolean $call
      * @param array $settings
@@ -151,7 +151,7 @@ class Client
      * @return boolean flag
      */
     private function _isBasicAuthenticationRequired($key, $secret)
-    {        
+    {
         return is_string($key) && is_string($secret) && empty($secret);
     }
 

--- a/src/Mailjet/Client.php
+++ b/src/Mailjet/Client.php
@@ -120,7 +120,7 @@ class Client
      * @param boolean $call
      * @param array $settings
      */
-    private function _setBasicAuthentication($key, $secret, $call, $settings)
+    private function _setBasicAuthentication($key, $secret, $call, array $settings)
     {
         $this->apikey    = $key;
         $this->apisecret = $secret;
@@ -134,7 +134,7 @@ class Client
      * @param boolean $call
      * @param array $settings
      */
-    private function _setTokenAuthetication($token, $call, $settings)
+    private function _setTokenAuthetication($token, $call, array $settings)
     {
         $this->apitoken = $token;
         $this->initSettings($call, $settings);
@@ -318,7 +318,7 @@ class Client
     /**
      * Set a backup if the variables generating the url are change during a call.
      */
-    private function initSettings($call, $settings = [])
+    private function initSettings($call, array $settings = [])
     {
         if (!empty($settings['url']) && is_string($settings['url'])) {
             $this->settings['url'] = $settings['url'];

--- a/src/Mailjet/Client.php
+++ b/src/Mailjet/Client.php
@@ -58,7 +58,7 @@ class Client
         if ($isBasicAuthentication) {
             $this->_setBasicAuthentication($key, $secret, $call, $settings);
         } else {
-            $this->_setTokenAuthetication($key, $call);
+            $this->_setTokenAuthetication($key, $call, $settings);
         }
     }
 

--- a/test/Mailjet/test.php
+++ b/test/Mailjet/test.php
@@ -29,7 +29,6 @@ class MailjetTest extends TestCase
     public function assertGetAuth($payload, $response)
     {
         $this->assertEquals($payload, $response->request->getAuth()[0]);
-        $this->assertEquals($payload, $response->request->getAuth()[1]);
     }
 
     public function assertGetStatus($payload, $response)
@@ -166,8 +165,8 @@ class MailjetTest extends TestCase
         $this->assertHttpMethod('POST', $ret);
         $this->assertGetAuth('', $ret);
         $this->assertGetStatus(401, $ret);
-        $this->assertGetBody(401, 'StatusCode', $ret);
-        $this->assertGetData(401, 'StatusCode', $ret);
+        $this->assertGetBody('', 'StatusCode', $ret);
+        $this->assertGetData('', 'StatusCode', $ret);
         $this->assertGetCount('', $ret);
         $this->assertGetReasonPhrase('Unauthorized', $ret);
         $this->assertGetTotal('', $ret);


### PR DESCRIPTION
With 1.4.0 (or maybe before ?), the init auth is broken if using the token auth, because the `setTokenAuth` is broken by design. It expects the token (string), the call status (bool) and settings (array)... and what is given is the token (string), the secret (string ??) and the call (bool). So PHP crashes with an illegal offset.

This tries to fix that. Adding typehint helps...