### PR TITLE
Update Client.php

### DIFF
--- a/src/Mailjet/Client.php
+++ b/src/Mailjet/Client.php
@@ -152,7 +152,7 @@ class Client
      */
     private function _isBasicAuthenticationRequired($key, $secret)
     {        
-        return is_string($key) && is_string($secret) && empty($secret);
+        return is_string($key) && is_string($secret) && !empty($secret);
     }
 
     /**


### PR DESCRIPTION
fixed function _isBasicAuthenticationRequired because of  a logical issue

 ```
private function _isBasicAuthenticationRequired($key, $secret)
    {        
        return is_string($key) && is_string($secret) && empty($secret);
    }
```
returns always false
