### PR TITLE
fixed basic authentication in client.php

### DIFF
--- a/src/Mailjet/Client.php
+++ b/src/Mailjet/Client.php
@@ -152,7 +152,7 @@ class Client
      */
     private function _isBasicAuthenticationRequired($key, $secret)
     {        
-        return is_string($key) && is_string($secret) && empty($secret);
+        return is_string($key) && is_string($secret) && !empty($secret);
     }
 
     /**


### PR DESCRIPTION
private function _isBasicAuthenticationRequired($key, $secret)
    {        
        return is_string($key) && is_string($secret) && empty($secret);
    }

must return always false, so the basic authentication is not working, so i changed it to:

```
private function _isBasicAuthenticationRequired($key, $secret)
    {        
        return is_string($key) && is_string($secret) && !empty($secret);
    }
```
