### PR TITLE
Update Minimum PHP to 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.6.0",
         "guzzlehttp/guzzle": "~6.0|~5.3"
     },
     "require-dev": {


### PR DESCRIPTION
Travis is only configured to test back to 5.6, increment minimum version to 5.6

https://github.com/mailjet/mailjet-apiv3-php/blob/11ce1cd2c5c451fa2ee8717f8fe3841d39cc8681/.travis.yml#L2-L8