### PR TITLE
Fix Travis CI build tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
 language: php
+dist: trusty
 php:
   - 7.0
   - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
   - 5.4
   - 5.5
   - 5.6
 install:
   - composer install
-script: phpunit --coverage-clover build/logs/clover.xml
+script: vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 after_success:
   - travis_retry vendor/bin/coveralls -v
 notifications:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "guzzlehttp/guzzle": "~6.0|~5.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^4.8.36|^5.7",
         "php-coveralls/php-coveralls": "^1.0"
     },
     "autoload": {

--- a/test/Mailjet/MailjetApiv3Test.php
+++ b/test/Mailjet/MailjetApiv3Test.php
@@ -52,12 +52,22 @@ class MailjetApiv3Test extends TestCase
 
     private function assertGetBody($payload, $keyName, $response)
     {
-        $this->assertEquals($payload, $response->getBody()[$keyName]);
+        $result = null;
+        if (empty($response->getBody()[$keyName]) === false) {
+            $result = $response->getBody()[$keyName];
+        }
+
+        $this->assertEquals($payload, $result);
     }
 
     private function assertGetData($payload, $keyName, $response)
     {
-        $this->assertEquals($payload, $response->getData()[$keyName]);
+        $result = null;
+        if (empty($response->getData()[$keyName]) === false) {
+            $result = $response->getData()[$keyName];
+        }
+
+        $this->assertEquals($payload, $result);
     }
 
     private function assertGetCount($payload, $response)


### PR DESCRIPTION
# Changed log
- To fix Travis CI builds, let the Travis CI build environment be `trusty` dist.
- Add `php-7.2`, `php-7.3` and `php-7.4` version tests during Travis CI build.
- The default PHPUnit versions on Travis CI build is not correct for every PHP version.
Using the `vendor/bin/phpunit` version instead.
- To avoid warning message about `PHP Notice:  Trying to access array offset on value of type null`, using `empty` function ti check array accessing value before accessing value from array directly.