### PR TITLE
Add support for V4

### DIFF
--- a/src/Mailjet/Client.php
+++ b/src/Mailjet/Client.php
@@ -236,6 +236,8 @@ class Client
             $path = '';
         } elseif (in_array($action, $this->dataAction)) {
             $path = 'DATA';
+        } elseif($this->version == 'v4') {
+            $path = '';
         }
 
         $arrayFilter = [$path, $resource, $id, $action, $actionid];


### PR DESCRIPTION
This change allows to delete contacts using v4. See https://dev.mailjet.com/email/guides/contact-management/#gdpr-delete-contacts . Without this, the REST path is included.