### PR TITLE
composer.json: move mockery/mockery into require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
         "php": "^7.2|^8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "~7.0",
-        "mockery/mockery": "^1.4",
         "psr/http-client": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8|^9",
+        "mockery/mockery": "^1.4",
         "php-coveralls/php-coveralls": "^2.0"
     },
     "autoload": {


### PR DESCRIPTION
its a dev-time only dependency which should not be part of the package from a library consumer point of view.

our package-consuming application is bloated by mockery/mockery and the additional depepdencies it has