### PR TITLE
chore: made setAuthentication public to allow credential changing

### DIFF
--- a/src/Mailjet/Client.php
+++ b/src/Mailjet/Client.php
@@ -261,7 +261,7 @@ class Client
      * @param bool $call
      * @param array $settings
      */
-    private function setAuthentication(string $key, ?string $secret, bool $call, array $settings = []): void
+    public function setAuthentication(string $key, ?string $secret, bool $call, array $settings = []): void
     {
         $isBasicAuth = $this->isBasicAuthentication($key, $secret);
 
@@ -371,7 +371,7 @@ class Client
 
         $arrayFilter = [$path, $resource, $id, $action, $actionid];
 
-        return $this->getApiUrl().implode('/', array_filter($arrayFilter));
+        return $this->getApiUrl() . implode('/', array_filter($arrayFilter));
     }
 
     /**


### PR DESCRIPTION
Hey!
So - we want to instantiate the Mailjet Client as a singleton with our master API credentials however for some of our 'customers' we want to be able to send requests dynamically to their sub-accounts without us having to re-instantiate a mailjet client constantly (we're going to be processing data at high volume so this will create a fair bit of overhead).

To allow us to switch credentials on the fly, we'd like the `setAuthentication` method to be public so we can just update our one instance for our sub-accounts instead of creating new clients constantly.

Happy to hear your thoughts around this! 