### PR TITLE
Added ability to add normalizers to API calls and normalize response before getting them in methods like `get`, `post`, `delete`, `put`;

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "php": "^8.1",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.4.4",
-        "psr/http-client": "^1.0"
+        "psr/http-client": "^1.0",
+        "symfony/validator": "6.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^8|^9",

--- a/src/Mailjet/Client.php
+++ b/src/Mailjet/Client.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Mailjet;
 
+use Mailjet\Normalizer\NormalizerInterface;
+
 class Client
 {
     public const WRAPPER_VERSION = Config::WRAPPER_VERSION;
@@ -118,6 +120,16 @@ class Client
         }
 
         $result = $this->_call('GET', $resource[0], $resource[1], $args);
+
+        if (isset($resource['normalizer']) && class_exists($resource['normalizer'])) {
+            /**
+             * @var $normalizer NormalizerInterface
+             */
+            $normalizer = $resource['normalizer'];
+            if ($normalizer::shouldBeNormalized($args)) {
+                $result = $normalizer::normalizeResponse($result);
+            }
+        }
 
         if (!empty($this->changed)) {
             $this->setSettings();

--- a/src/Mailjet/Normalizer/ContactNormalizer.php
+++ b/src/Mailjet/Normalizer/ContactNormalizer.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Mailjet\Normalizer;
+
+use Mailjet\Response;
+
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Validation;
+
+class ContactNormalizer implements NormalizerInterface
+{
+    /**
+     * @param Response $response
+     * @return Response
+     */
+    public static function normalizeResponse(Response $response): Response
+    {
+        if (!$response->getData()) {
+            $response->setData($response->getBody());
+        }
+        return $response;
+    }
+
+    /**
+     * @param array $data
+     * @return bool
+     */
+    public static function shouldBeNormalized(array $data): bool
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, self::getValidationRule());
+        return 0 === count($violations);
+    }
+
+    /**
+     * @return Assert\Collection
+     */
+    private static function getValidationRule(): Assert\Collection
+    {
+        return new Assert\Collection([
+            'fields' => [
+                'filters' => new Assert\Collection([
+                    'countonly' => new Assert\Length(['min' => 1]),
+                ]),
+            ],
+            'allowMissingFields' => false,
+        ]);
+    }
+}

--- a/src/Mailjet/Normalizer/NormalizerInterface.php
+++ b/src/Mailjet/Normalizer/NormalizerInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Mailjet\Normalizer;
+
+use Mailjet\Response;
+
+interface NormalizerInterface
+{
+    /**
+     * @param Response $response
+     * @return Response
+     */
+    public static function normalizeResponse(Response $response): Response;
+
+    /**
+     * @param array $data
+     * @return bool
+     */
+    public static function shouldBeNormalized(array $data): bool;
+}

--- a/src/Mailjet/Resources.php
+++ b/src/Mailjet/Resources.php
@@ -11,15 +11,13 @@ declare(strict_types=1);
 
 namespace Mailjet;
 
+use Mailjet\Normalizer\ContactNormalizer;
+
 /**
- *
  * This is the Mailjet Resources Class
- *
  * @category Mailjet_API
- *
  * @author  Guillaume Badi <gbadi@mailjet.com>
  * @license MIT https://opensource.org/licenses/MIT
- *
  * @see dev.mailjet.com
  */
 class Resources
@@ -47,7 +45,7 @@ class Resources
     public static $Campaignoverview = ['campaignoverview', ''];
     public static $Campaignstatistics = ['campaignstatistics', ''];
     public static $Clickstatistics = ['clickstatistics', ''];
-    public static $Contact = ['contact', ''];
+    public static $Contact = ['contact', '', 'normalizer' => ContactNormalizer::class];
     public static $Contacts = ['contacts', ''];
     public static $ContactManagecontactslists = ['contact', 'managecontactslists'];
     public static $ContactGetcontactslists = ['contact', 'getcontactslists'];

--- a/src/Mailjet/Response.php
+++ b/src/Mailjet/Response.php
@@ -40,6 +40,8 @@ class Response
      */
     private $request;
 
+    private $data;
+
     /**
      * Construct a Mailjet response.
      *
@@ -55,6 +57,7 @@ class Response
             $this->status = $response->getStatusCode();
             $this->body = $this->decodeBody($response->getBody()->getContents());
             $this->success = 2 == floor($this->status / 100);
+            $this->data = $this->body['Data'] ?? $this->body;
         }
     }
 
@@ -86,7 +89,7 @@ class Response
      */
     public function getData(): array
     {
-        return $this->body['Data'] ?? $this->body;
+        return $this->data ?? [];
     }
 
     /**
@@ -144,5 +147,13 @@ class Response
     protected function decodeBody(string $body): array
     {
         return json_decode($body, true, 512, JSON_BIGINT_AS_STRING) ?: [];
+    }
+
+    /**
+     * @param mixed $data
+     */
+    public function setData($data): void
+    {
+        $this->data = $data;
     }
 }


### PR DESCRIPTION
Added ability to add normalizers to API calls and normalize response before getting them in methods like `get`, `post`, `delete`, `put`;

- Resolved problem with Resource::$Contact. Now, when we apply filter `countonly` response will be consistent 

- Added Symfony validator package to system