### PR TITLE
Allow Symfony LTS 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.4.4",
         "psr/http-client": "^1.0",
-        "symfony/validator": "^6.3|^7.0"
+        "symfony/validator": "^5.4|^6.0|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5.13",


### PR DESCRIPTION
The Collection and Length assertion used since 1.6.2 are supported by Symfony since forever.
Restricting future mailjet api updates to Symfony 6.3 or more seems overkill, and drop the still supported 5.4 away.

This PR brings compatibility with Symfony 5.4