### PR TITLE
Resolves deprecation introduced in PHP 8.4 (implicit nullable)

### DIFF
--- a/src/Mailjet/Client.php
+++ b/src/Mailjet/Client.php
@@ -77,7 +77,7 @@ class Client
      * @param bool        $call     performs the call or not
      * @param array       $settings
      */
-    public function __construct(string $key, string $secret = null, bool $call = true, array $settings = [])
+    public function __construct(string $key, ?string $secret = null, bool $call = true, array $settings = [])
     {
         $this->setAuthentication($key, $secret, $call, $settings);
     }


### PR DESCRIPTION
Resolves deprecation introduced in PHP 8.4: 

```
deprecated: 8192 :: Mailjet\Client::__construct(): Implicitly marking parameter $secret as nullable is 
deprecated, the explicit nullable type must be used instead on line 80 of  `../vendor/mailjet/mailjet-apiv3-php/src/Mailjet/Client.php`
```

https://www.php.net/releases/8.4/en.php