### PR TITLE
Fix typed error when api secret is not set but called

### DIFF
--- a/src/Mailjet/Client.php
+++ b/src/Mailjet/Client.php
@@ -310,6 +310,7 @@ class Client
             $this->apitoken = $key;
             $this->version = Config::SMS_VERSION;
             $this->apikey = '';
+            $this->apisecret = '';
         }
 
         $this->initSettings($call, $settings);


### PR DESCRIPTION
It looks like the same bug as PR https://github.com/mailjet/mailjet-apiv3-php/pull/321 exists with the `$apisecret` property. 
This PR fixes it.

