### PR TITLE
Fix: Replace deprecated Symfony Validator array syntax with named arguments

### DIFF
--- a/src/Mailjet/Normalizer/ContactNormalizer.php
+++ b/src/Mailjet/Normalizer/ContactNormalizer.php
@@ -37,19 +37,15 @@ class ContactNormalizer implements NormalizerInterface
     private static function getValidationRule(): Assert\Collection
     {
         return new Assert\Collection(
-            [
-            'fields' => [
+            fields: [
                 'filters' => new Assert\Collection(
-                    [
-                    'fields' => [
-                        'countonly' => new Assert\Length(['min' => 1]),
+                    fields: [
+                        'countonly' => new Assert\Length(min: 1),
                     ],
-                    'allowExtraFields' => true,
-                    ]
+                    allowExtraFields: true
                 ),
             ],
-            'allowExtraFields' => true,
-            ]
+            allowExtraFields: true
         );
     }
 }


### PR DESCRIPTION
- Changed Assert\Length(['min' => 1]) to Assert\Length(min: 1)
- Changed Assert\Collection with array parameters to use named arguments
- Fixes all Symfony 7.3+ deprecation warnings in ContactNormalizer
- All unit tests pass successfully

Resolves deprecation warnings:
- 'Passing an array of options to configure Length constraint is deprecated'
- 'Passing an array of options to configure Collection constraint is deprecated'

Related to issue about Symfony 7.3 deprecations in mailjet API

fix for this issue https://github.com/mailjet/mailjet-apiv3-php/issues/323