### PR TITLE
Fix #325: Force IPv4 by default to prevent SSL_ERROR_SYSCALL

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,24 @@ $mj = new \Mailjet\Client(getenv('MJ_APIKEY_PUBLIC'),
 
 If your account has been moved to Mailjet's US architecture, the URL value you need to set is `api.us.mailjet.com`.
 
+#### Network Connectivity
+
+By default, the library forces IPv4 connections to avoid intermittent SSL connection issues on servers with misconfigured IPv6. This resolves the common `SSL_ERROR_SYSCALL` error.
+
+If you need to use IPv6 or system default, you can override this setting:
+
+```php
+$mj = new \Mailjet\Client(getenv('MJ_APIKEY_PUBLIC'), getenv('MJ_APIKEY_PRIVATE'));
+
+// Use IPv6
+$mj->addRequestOption('force_ip_resolve', 'v6');
+
+// Or use system default (both IPv4 and IPv6)
+$mj->addRequestOption('force_ip_resolve', null);
+```
+
+**Note:** If you experience intermittent connection failures, ensure IPv4 forcing is enabled (default behavior).
+
 ### Disable API call
 
 By default the API call parameter is always enabled. However, you may want to disable it during testing to prevent unnecessary calls to the Mailjet API. This is done by setting the third parameter to `false`:

--- a/src/Mailjet/Client.php
+++ b/src/Mailjet/Client.php
@@ -52,6 +52,7 @@ class Client
     private array $requestOptions = [
         self::TIMEOUT => 15,
         self::CONNECT_TIMEOUT => 2,
+        'force_ip_resolve' => 'v4',
     ];
     /**
      * @var string[]


### PR DESCRIPTION
- Add 'force_ip_resolve' => 'v4' to default requestOptions
- Fixes intermittent SSL connection errors on servers with misconfigured IPv6
- Users can still override to use IPv6 or system default if needed
- Update README with Network Connectivity documentation